### PR TITLE
Remove coveralls from project, and move into circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,5 +28,3 @@ jobs:
 
       - store_artifacts:
           path: ./coverage
-
-      - run: yarn run coveralls

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "build:prod": "webpack -p",
     "contributors:add": "all-contributors add",
     "contributors:generate": "all-contributors generate",
-    "coveralls": "cat coverage/lcov.info | node_modules/coveralls/bin/coveralls.js",
     "precommit": "lint-staged"
   },
   "repository": {


### PR DESCRIPTION
Moving coveralls actions to be internally inside Circle CI instead of using the error-prone npm script. This lets us embed the token easily.