### PR TITLE
Add scrollById feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ export default class MyComponent extends Component {
 ```
 
 ```jsx
-// Scroll to position (0, 500) within a provided container
+// Scroll to position (0, 500) within all provided <ScrollArea /> children
 import React, { Component } from "react";
 import { ScrollTo, ScrollArea } from "react-scroll-to";
 
@@ -61,6 +61,36 @@ export default class MyComponent extends Component {
                           Scroll within this container
                         </button>
                       </ScrollArea>
+                  )
+                }
+            </ScrollTo>
+        );
+    }
+}
+```
+
+```jsx
+// Scroll to position (0, 500) within a specific <ScrollArea /> child
+import React, { Component } from "react";
+import { ScrollTo, ScrollArea } from "react-scroll-to";
+
+export default class MyComponent extends Component {
+    render() {
+        return (
+            <ScrollTo>
+                {
+                  (scroll, scrollById) => (
+                      <div>
+                          <ScrollArea id="foo" style={{ height: 1000 }}>
+                              <button onClick={() => scrollById("foo", 0, 500)}>
+                                  Scroll within this container
+                              </button>
+                          </ScrollArea>
+
+                          <ScrollArea style={{ height: 1000 }}>
+                              This container won't scroll
+                          </ScrollArea>
+                      </div>
                   )
                 }
             </ScrollTo>
@@ -86,7 +116,7 @@ export default ScrollToHOC(function(props) {
 ```
 
 ```jsx
-// Scroll to position (0, 500) within a provided container
+// Scroll to position (0, 500) within all provided <ScrollArea /> children
 import React from "react";
 import { ScrollToHOC, ScrollArea } from "react-scroll-to";
 
@@ -97,6 +127,28 @@ export default ScrollToHOC(function(props) {
                 Scroll to Bottom
             </a>
         </ScrollArea>
+    );
+})
+```
+
+```jsx
+// Scroll to position (0, 500) within a specific <ScrollArea /> child
+import React from "react";
+import { ScrollToHOC, ScrollArea } from "react-scroll-to";
+
+export default ScrollToHOC(function(props) {
+    return (
+        <div>
+            <ScrollArea id="foo" style={{ height: 1000 }}>
+                <a onClick={() => props.scrollById("foo", 0, 500)}>
+                    Scroll to Bottom
+                </a>
+            </ScrollArea>
+
+            <ScrollArea style={{ height: 1000 }}>
+              This container won't scroll
+            </ScrollArea>
+        </div>
     );
 })
 ```

--- a/src/ScrollArea.jsx
+++ b/src/ScrollArea.jsx
@@ -1,20 +1,23 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import generateId from "./generateId";
 
 class ScrollArea extends Component {
   componentDidMount() {
-    this.context.addScrollArea(this.node);
+    this.id = this.node.id || generateId();
+
+    this.context.addScrollArea(this.node, this.id);
   }
 
   componentWillUnmount() {
-    this.context.removeScrollArea(this.node);
+    this.context.removeScrollArea(this.node, this.id);
   }
 
   render() {
     const { children, ...props } = this.props;
 
     return (
-      <div {...props} ref={node => this.node = node}>
+      <div {...props} ref={node => (this.node = node)}>
         {children}
       </div>
     );

--- a/src/ScrollArea.spec.jsx
+++ b/src/ScrollArea.spec.jsx
@@ -1,7 +1,8 @@
 import React from "react";
-import { shallow, mount } from "enzyme";
+import { mount } from "enzyme";
 import toJSON from "enzyme-to-json";
 import ScrollArea from "./ScrollArea";
+jest.mock("./generateId", () => () => "mock-id");
 
 describe("Test Scroll Area.", () => {
   it("should call addScrollArea when mounting.", () => {
@@ -36,7 +37,7 @@ describe("Test Scroll Area.", () => {
   });
 
   it("should render correctly.", () => {
-    const wrapper = shallow(
+    const wrapper = mount(
       <ScrollArea className="foo">
         <h1>Test</h1>
       </ScrollArea>,

--- a/src/ScrollTo.jsx
+++ b/src/ScrollTo.jsx
@@ -11,36 +11,48 @@ class ScrollTo extends Component {
   constructor(props) {
     super(props);
 
-    this.scrollArea = [];
+    this.scrollArea = {};
     this.handleScroll = this.handleScroll.bind(this);
+    this.handleScrollById = this.handleScrollById.bind(this);
   }
 
   getChildContext() {
     return {
-      addScrollArea: ref => {
-        this.scrollArea = this.scrollArea.concat(ref);
+      addScrollArea: (ref, id) => {
+        this.scrollArea[id] = ref;
       },
-      removeScrollArea: ref => {
-        this.scrollArea = this.scrollArea.filter(container => {
-          return container !== ref;
-        });
+      removeScrollArea: (ref, id) => {
+        delete this.scrollArea[id];
       }
     };
   }
 
   handleScroll(x, y) {
-    if (this.scrollArea.length === 0) {
+    const scrollAreaKeys = Object.keys(this.scrollArea);
+
+    if (scrollAreaKeys.length === 0) {
       scrollWindow(x, y);
     } else {
-      this.scrollArea.forEach(container => {
-        container.scrollLeft = x;
-        container.scrollTop = y;
+      scrollAreaKeys.forEach(key => {
+        this.scrollArea[key].scrollLeft = x;
+        this.scrollArea[key].scrollTop = y;
       });
     }
-  };
+  }
+
+  handleScrollById(id, x, y) {
+    const node = this.scrollArea[id];
+    if (node) {
+      node.scrollLeft = x;
+      node.scrollTop = y;
+    }
+  }
 
   render() {
-    return this.props.children && this.props.children(this.handleScroll);
+    return (
+      this.props.children &&
+      this.props.children(this.handleScroll, this.handleScrollById)
+    );
   }
 }
 

--- a/src/ScrollTo.spec.jsx
+++ b/src/ScrollTo.spec.jsx
@@ -1,6 +1,5 @@
 import React from "react";
-import PropTypes from "prop-types";
-import { shallow, mount } from "enzyme";
+import { shallow } from "enzyme";
 import toJSON from "enzyme-to-json";
 import ScrollTo from "./ScrollTo";
 
@@ -59,9 +58,9 @@ describe("Test render prop.", () => {
     const wrapper = shallow(<ScrollTo>{scroll => <div>Test</div>}</ScrollTo>);
 
     const childContext = wrapper.instance().getChildContext();
-    childContext.addScrollArea("foo");
+    childContext.addScrollArea("foo", "foo-id");
 
-    expect(wrapper.instance().scrollArea).toMatchSnapshot("foo");
+    expect(wrapper.instance().scrollArea).toMatchSnapshot();
   });
 
   it("Should remove scroll area.", () => {
@@ -71,7 +70,7 @@ describe("Test render prop.", () => {
 
     childContext.removeScrollArea("foo");
 
-    expect(wrapper.instance().scrollArea).toEqual([]);
+    expect(wrapper.instance().scrollArea).toEqual({});
   });
 
   it("Should update scroll position of ScrollArea's if present, rather than window", () => {
@@ -86,6 +85,52 @@ describe("Test render prop.", () => {
     );
     const childContext = wrapper.instance().getChildContext();
     childContext.addScrollArea(mockNode);
+
+    const buttonEl = wrapper.find("button");
+    buttonEl.simulate("click");
+
+    expect(mockNode).toMatchSnapshot();
+  });
+
+  it("Should scroll by ID", () => {
+    const mockNode = {
+      scrollLeft: 0,
+      scrollTop: 0,
+      id: "foo"
+    };
+    const wrapper = shallow(
+      <ScrollTo>
+        {(scroll, scrollById) => (
+          <button onClick={() => scrollById("foo", 100, 200)}>test</button>
+        )}
+      </ScrollTo>
+    );
+    const childContext = wrapper.instance().getChildContext();
+    childContext.addScrollArea(mockNode, "foo");
+
+    const buttonEl = wrapper.find("button");
+    buttonEl.simulate("click");
+
+    expect(mockNode).toMatchSnapshot();
+  });
+
+  it("Should not break if scrolling by an unknown ID", () => {
+    const mockNode = {
+      scrollLeft: 0,
+      scrollTop: 0,
+      id: "foo"
+    };
+    const wrapper = shallow(
+      <ScrollTo>
+        {(scroll, scrollById) => (
+          <button onClick={() => scrollById("unknown-id", 100, 200)}>
+            test
+          </button>
+        )}
+      </ScrollTo>
+    );
+    const childContext = wrapper.instance().getChildContext();
+    childContext.addScrollArea(mockNode, "foo");
 
     const buttonEl = wrapper.find("button");
     buttonEl.simulate("click");

--- a/src/__snapshots__/ScrollArea.spec.jsx.snap
+++ b/src/__snapshots__/ScrollArea.spec.jsx.snap
@@ -7,6 +7,7 @@ Array [
       Test
     </h1>
   </div>,
+  "mock-id",
 ]
 `;
 
@@ -17,15 +18,20 @@ Array [
       Test
     </h1>
   </div>,
+  "mock-id",
 ]
 `;
 
 exports[`Test Scroll Area. should render correctly. 1`] = `
-<div
+<ScrollArea
   className="foo"
 >
-  <h1>
-    Test
-  </h1>
-</div>
+  <div
+    className="foo"
+  >
+    <h1>
+      Test
+    </h1>
+  </div>
+</ScrollArea>
 `;

--- a/src/__snapshots__/ScrollTo.spec.jsx.snap
+++ b/src/__snapshots__/ScrollTo.spec.jsx.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Test render prop. Should add scroll area. 1`] = `
+Object {
+  "foo-id": "foo",
+}
+`;
+
+exports[`Test render prop. Should not break if scrolling by an unknown ID 1`] = `
+Object {
+  "id": "foo",
+  "scrollLeft": 0,
+  "scrollTop": 0,
+}
+`;
+
 exports[`Test render prop. Should pass correct context to children. 1`] = `
 Object {
   "addScrollArea": [Function],
@@ -15,15 +29,17 @@ exports[`Test render prop. Should render the functional children. 1`] = `
 </div>
 `;
 
-exports[`Test render prop. Should update scroll position of ScrollArea's if present, rather than window 1`] = `
+exports[`Test render prop. Should scroll by ID 1`] = `
 Object {
+  "id": "foo",
   "scrollLeft": 100,
   "scrollTop": 200,
 }
 `;
 
-exports[`foo 1`] = `
-Array [
-  "foo",
-]
+exports[`Test render prop. Should update scroll position of ScrollArea's if present, rather than window 1`] = `
+Object {
+  "scrollLeft": 100,
+  "scrollTop": 200,
+}
 `;

--- a/src/generateId.js
+++ b/src/generateId.js
@@ -1,0 +1,13 @@
+/**
+ * Generate a pseudo-unique ID on each function call
+ *
+ * @returns {number}
+ */
+
+const generateId = (() => {
+  let counter = 0;
+
+  return () => `scrollto-${counter++}`;
+})();
+
+export default generateId;

--- a/src/generateId.spec.js
+++ b/src/generateId.spec.js
@@ -1,0 +1,7 @@
+import generateId from "./generateId";
+
+it("should return a unique ID whenever it is called", () => {
+  expect(generateId()).toEqual("scrollto-0");
+  expect(generateId()).toEqual("scrollto-1");
+  expect(generateId()).toEqual("scrollto-2");
+});


### PR DESCRIPTION
Closes #37.

# Changes made to ScrollTo
  * `this.scrollArea` is now an object. Each value in `this.scrollArea` refers to a `refNode`

# Changes made to ScrollArea
  * It generates an `id` if the user doesn't provide one.
  * When calling `this.context.addScrollArea` and `this.context.removeScrollArea`, it uses the `id` as its key value.
