### PR TITLE
Add scrollById as a prop in HOC component

### DIFF
--- a/src/ScrollToHOC.jsx
+++ b/src/ScrollToHOC.jsx
@@ -9,7 +9,11 @@ import ScrollTo from "./ScrollTo";
  */
 function ScrollToHOC(Component) {
   const WrappedComponent = props => (
-    <ScrollTo>{scroll => <Component {...props} scroll={scroll} />}</ScrollTo>
+    <ScrollTo>
+      {(scroll, scrollById) => (
+        <Component {...props} scroll={scroll} scrollById={scrollById} />
+      )}
+    </ScrollTo>
   );
   WrappedComponent.displayName = `WithScrollToHOC(${getDisplayName(
     Component

--- a/src/tests/ScrollToHOC.spec.jsx
+++ b/src/tests/ScrollToHOC.spec.jsx
@@ -31,4 +31,27 @@ describe("Test HOC.", () => {
     expect(window.scroll).toHaveBeenCalledTimes(1);
     expect(window.scroll.mock.calls[0]).toEqual([100, 200]);
   });
+
+  it("Should call scrollById.", () => {
+    const mockNode = {
+      scrollLeft: 0,
+      scrollTop: 0,
+      id: "foo"
+    };
+    const WrappedComponent = ScrollToHOC(props => {
+      return(
+        <div>
+          <div id="foo"> </div>
+          <button onClick={() => props.scrollById("foo", 100, 200)}>
+            test
+          </button>
+        </div>
+      )
+    });
+    const wrapper = mount(<WrappedComponent />);
+
+    const buttonEl = wrapper.find("button");
+    buttonEl.simulate("click");
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
 });

--- a/src/tests/__snapshots__/ScrollToHOC.spec.jsx.snap
+++ b/src/tests/__snapshots__/ScrollToHOC.spec.jsx.snap
@@ -1,10 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Test HOC. Should call scrollById. 1`] = `
+<WithScrollToHOC(Unknown)>
+  <ScrollTo>
+    <Component
+      scroll={[Function]}
+      scrollById={[Function]}
+    >
+      <div>
+        <div
+          id="foo"
+        >
+           
+        </div>
+        <button
+          onClick={[Function]}
+        >
+          test
+        </button>
+      </div>
+    </Component>
+  </ScrollTo>
+</WithScrollToHOC(Unknown)>
+`;
+
 exports[`Test HOC. Should render the functional children. 1`] = `
 <WithScrollToHOC(test)>
   <ScrollTo>
     <test
       scroll={[Function]}
+      scrollById={[Function]}
     >
       <div>
         test


### PR DESCRIPTION
The HOC component doesn't seem to pass `scrollById` as a prop to wrapping component. This PR adds the `sccrollById` to the props object.