### PR TITLE
Hide unneeded files from NPM

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,14 @@
-./example/*
-./src/*
+./src
 ./node_modules/*
+./.circleci/*
 
-./yarn.lock
-./webpack.config.js
-./.gitignore
-./.all-contributorsrc
-./CODE_OF_CONDUCT
+*.lock
+webpack.config.js
+.gitignore
+.all-contributorsrc
+.eslintrc.js
+.babelrc
+CODE_OF_CONDUCT.md
+ISSUE_TEMPLATE.md
+
+*.log


### PR DESCRIPTION
Hide extranious files from NPM when published to reduce the footprint of the library